### PR TITLE
Minor fixes to test html files

### DIFF
--- a/tests/0015.html
+++ b/tests/0015.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <div itemscope="" itemtype="http://schema.org/Thing">
-  <object itemprop="object" data="foo"/>
+  <object itemprop="object" data="foo"></object>
 </div>

--- a/tests/0075.html
+++ b/tests/0075.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div itemscope="" itemtype="http://schema.org/Thing">
-      <data itemprop="data" value="1.1"/>
+      <data itemprop="data" value="1.1"></data>
     </div>
   </body>
 </html>

--- a/tests/0076.html
+++ b/tests/0076.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div itemscope="" itemtype="http://schema.org/Thing">
-      <data itemprop="data" value="1"/>
+      <data itemprop="data" value="1"></data>
     </div>
   </body>
 </html>

--- a/tests/0077.html
+++ b/tests/0077.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div itemscope="" itemtype="http://schema.org/Thing">
-      <data itemprop="data" value="foo"/>
+      <data itemprop="data" value="foo"></data>
     </div>
   </body>
 </html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -104,7 +104,7 @@
     <span itemscope itemid="http://www.w3.org/ns/rdftest#registry" itemtype="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property">
       <code itemprop="http://www.w3.org/2000/01/rdf-schema#label">registry</code>
       property, indicating the URL of a <em itemprop="http://www.w3.org/2000/01/rdf-schema#comment">Test Registry</em>
-      to load when executing a particular <a itemprop="http://www.w3.org/2000/01/rdf-schema#domain" href="http://www.w3.org/ns/rdftest#Test">Test</a>.</span>
+      to load when executing a particular <a itemprop="http://www.w3.org/2000/01/rdf-schema#domain" href="http://www.w3.org/ns/rdftest#Test">Test</a>.
     </span>
     typically a file co-located and numbered along with the test itself.</p>
   <section><h3>Example Test Entry</h3>

--- a/tests/sdo_eg_md_10.html
+++ b/tests/sdo_eg_md_10.html
@@ -1,37 +1,37 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Web Schemas TF: Schema.org tests: test 10 (format md)</title>
+    <title>Web Schemas TF: Schema.org tests: test 10 (format md)</title>
 </head>
 <body>
 
 <div itemscope itemtype="http://schema.org/Product">
-  <img itemprop="image" src="dell-30in-lcd.jpg" />
-  <span itemprop="name">Dell UltraSharp 30" LCD Monitor</span>
+    <img itemprop="image" src="dell-30in-lcd.jpg"/>
+    <span itemprop="name">Dell UltraSharp 30" LCD Monitor</span>
 
-  <div itemprop="aggregateRating"
-    itemscope itemtype="http://schema.org/AggregateRating">
-    <span itemprop="ratingValue">87</span>
-    out of <span itemprop="bestRating">100</span>
-    based on <span itemprop="ratingCount">24</span> user ratings
-  </div>
+    <div itemprop="aggregateRating"
+         itemscope itemtype="http://schema.org/AggregateRating">
+        <span itemprop="ratingValue">87</span>
+        out of <span itemprop="bestRating">100</span>
+        based on <span itemprop="ratingCount">24</span> user ratings
+    </div>
 
-  <div itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer">
-    <span itemprop="lowPrice">$1250</span>
-    to <span itemprop="highPrice">$1495</span>
-    from <span itemprop="offerCount">8</span> sellers
+    <div itemprop="offers" itemscope itemtype="http://schema.org/AggregateOffer">
+        <span itemprop="lowPrice">$1250</span>
+        to <span itemprop="highPrice">$1495</span>
+        from <span itemprop="offerCount">8</span> sellers
 
-  Sellers:
-  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    <a itemprop="url" href="save-a-lot-monitors.com/dell-30.html">
-     Save A Lot Monitors - $1250</a>
-  </div>
-  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    <a itemprop="url" href="jondoe-gadgets.com/dell-30.html">
-     Jon Doe's Gadgets - $1350</a>
-  </div>
-  ...
+        Sellers:
+        <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+            <a itemprop="url" href="save-a-lot-monitors.com/dell-30.html">
+                Save A Lot Monitors - $1250</a>
+        </div>
+        <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+            <a itemprop="url" href="jondoe-gadgets.com/dell-30.html">
+                Jon Doe's Gadgets - $1350</a>
+        </div>
+        ...
+    </div>
 </div>
-
 </body>
 </html>

--- a/tests/sdo_eg_md_13.html
+++ b/tests/sdo_eg_md_13.html
@@ -12,11 +12,11 @@
 
 <div itemprop="video" itemscope itemtype="http://schema.org/VideoObject">
   <h2>Video: <span itemprop="name">Interview with the Foo Fighters</span></h2>
-  <meta itemprop="duration" content="T1M33S" />
-  <meta itemprop="thumbnail" content="foo-fighters-interview-thumb.jpg" />
-  <object ...>
-    <param ...>
-    <embed type="application/x-shockwave-flash" ...>
+  <meta itemprop="duration" content="T1M33S"  property="theft" />
+  <meta itemprop="thumbnail" content="foo-fighters-interview-thumb.jpg" property="alienable" />
+  <object >
+    <param name="foo" value="bar">
+    <embed type="application/x-shockwave-flash">
   </object>
   <span itemprop="description">Catch this exclusive interview with
     Dave Grohl and the Food Fighters about their new album, Rope.</span>
@@ -27,9 +27,9 @@
 
 <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
   <span itemprop="name">Rope</span>
-  <meta itemprop="url" content ="foo-fighters-rope.html">
-  Length: <meta itemprop="duration" content="PT4M5S">4:05 -
-  14300 plays<meta itemprop="interactionCount" content="UserPlays:14300" />
+  <meta itemprop="url" content ="foo-fighters-rope.html" property="foo">
+  Length: <meta itemprop="duration" content="PT4M5S" property="bar">4:05 -
+  14300 plays<meta itemprop="interactionCount" content="UserPlays:14300"  property="bar"/>
   <a href="foo-fighters-rope-play.html" itemprop="audio">Play</a>
   <a href="foo-fighters-rope-buy.html" itemprop="offers">Buy</a>
   From album: <a href="foo-fighters-wasting-light.html"
@@ -38,8 +38,8 @@
 
 <div itemprop="track" itemscope itemtype="http://schema.org/MusicRecording">
   <span itemprop="name">Everlong</span>
-  <meta itemprop="url" content ="foo-fighters-everlong.html">
-  Length: <meta itemprop="duration" content="PT6M33S">6:33 -
+  <meta itemprop="url" content ="foo-fighters-everlong.html" property="bar">
+  Length: <meta itemprop="duration" content="PT6M33S" property="bar">6:33 -
   <span itemprop="playCount">11700</span> plays
   <a href="foo-fighters-everlong-play.html" itemprop="audio">Play</a>
   <a href="foo-fighters-everlong-buy.html" itemprop="offers">Buy</a>
@@ -55,7 +55,7 @@
     <span itemprop="name">FedExForum</span>
   </a>
   <span itemprop="location">Memphis, TN, US</span>
-  <meta itemprop="startDate" content="2011-05-20">May 20
+  <meta itemprop="startDate" content="2011-05-20" property="bar">May 20
   <a href="ticketmaster.com/foofighters/may20-2011" itemprop="offers">Buy tickets</a>
 </div>
 
@@ -64,7 +64,7 @@
     <span itemprop="name">Mid America Center</span>
   </a>
   <span itemprop="location">Council Bluffs, IA, US</span>
-  <meta itemprop="startDate" content="2011-05-23">May 23
+  <meta itemprop="startDate" content="2011-05-23" property="bar">May 23
   <a href="ticketmaster.com/foofighters/may23-2011" itemprop="offers">Buy tickets</a>
 </div>
 
@@ -77,7 +77,7 @@
 <h2>Comments:</h2>
 Excited about seeing them in concert next week. -Lawrence , Jan 23
 I dig their latest single. -Mary, Jan 19
-<meta itemprop="interactionCount" content="UserComments:18" />
+<meta itemprop="interactionCount" content="UserComments:18"  property="foo"/>
 Showing 1-2 of 18 comments. <a href="foofighters-comments">More</a>
 
 </div>

--- a/tests/sdo_eg_md_16.html
+++ b/tests/sdo_eg_md_16.html
@@ -18,7 +18,7 @@
       <td>John Adams (1797-1801)</td>
       <td>Federalist</td>
     </tr>
-    ...
+    <tr><td>...</td></tr>
   </table>
 </div>
 

--- a/tests/sdo_eg_md_29.html
+++ b/tests/sdo_eg_md_29.html
@@ -1,25 +1,25 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Web Schemas TF: Schema.org tests: test 29 (format md)</title>
+    <title>Web Schemas TF: Schema.org tests: test 29 (format md)</title>
 </head>
 
 <body itemscope itemtype="http://schema.org/MedicalWebPage">
-  <link itemprop="audience" href="http://schema.org/Patient" />
-  <link itemprop="specialty" href="http://schema.org/Cardiovascular" />
-  <meta itemprop="lastReviewed" content="2011-09-14"/>
-  <h1>About
+<link itemprop="audience" href="http://schema.org/Patient"/>
+<link itemprop="specialty" href="http://schema.org/Cardiovascular"/>
+<meta itemprop="lastReviewed" content="2011-09-14"/>
+<h1>About
     <span itemprop="about" itemscope itemtype="http://schema.org/MedicalCondition">
       <span itemprop="name">High Blood Pressure</span>
       (<span itemprop="name">hypertension</span>)</span>
-  </h1>
-  ...
-  <h2><span itemprop="aspect">Diagnosis</span></h2>
-  High blood pressure is diagnosed by measuring ...
-  ...
-  <h2><span itemprop="aspect">Treatment</span></h2>
-  There are many common treatments for high blood pressure,
-  including
+</h1>
+...
+<h2><span itemprop="aspect">Diagnosis</span></h2>
+High blood pressure is diagnosed by measuring ...
+...
+<h2><span itemprop="aspect">Treatment</span></h2>
+There are many common treatments for high blood pressure,
+including
   <span itemscope itemtype="http://schema.org/DrugClass">
     <span itemprop="name">beta-blocker</span> drugs such as
     <span itemprop="drug" itemscope itemtype="http://schema.org/Drug">
@@ -32,6 +32,7 @@
       (<span itemprop="otherName">Tenormin</span>)
     </span> ...
   ...
+  </span>
 </body>
 
 </html>


### PR DESCRIPTION
Add missing close tags, attributes, etc so that nu.validator stops kvetching.  

None of the missing tags / self-closing non-void tags was anywhere dangerous
